### PR TITLE
Don't log client errors as FlowError

### DIFF
--- a/app/lib/ErrorHandler.scala
+++ b/app/lib/ErrorHandler.scala
@@ -12,9 +12,9 @@ class ErrorHandler extends HttpErrorHandler with Errors {
 
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
     val errorId = generateErrorId()
-    Logger.warn(s"[proxy] FlowError Client Error $errorId path[${request.uri}] status[$statusCode]: $message")
+    Logger.warn(s"[proxy] Client Error $errorId path[${request.uri}] status[$statusCode]: $message")
     Future.successful(
-      Status(statusCode)(clientErrors(Seq(s"A client error occurred: $message")))
+      Status(statusCode)(clientErrors(Seq(s"Invalid request (err #$errorId)")))
     )
   }
 


### PR DESCRIPTION
- Ex:
   [proxy] FlowError Client Error proxy862ffef2de3349428f0fcc9b5083decc path[/language/Swedish${IFS}&&echo${IFS}610cker>qt&&tar${IFS}/string.js] status[400]: Illegal character in path at index 18: /language/Swedish${IFS}&&echo${IFS}610cker>qt&&tar${IFS}/string.js

 - Just log a a warning