### PR TITLE
Log form bodies

### DIFF
--- a/app/lib/LoggingUtil.scala
+++ b/app/lib/LoggingUtil.scala
@@ -1,0 +1,60 @@
+package lib
+
+import play.api.libs.json._
+
+object LoggingUtil {
+
+  // All fields in this array will have their values redacted
+  private[this] val GlobalFieldsToReplace = Seq("cvv", "number")
+
+  // Map from apidoc model type to list of fields to whitelist
+  private[this] val WhiteListByType = Map(
+    "item_form" -> Seq("number"),
+    "harmonized_item_form" -> Seq("number"),
+    "order_form" -> Seq("number")
+  )
+
+  /**
+    * Accepts a JsValue, redacting any fields that may contain sensitive data
+    * @param body The JsValue itself
+    * @param typ The type represented by the JsValue if resolved from the apidoc specification
+    */
+  def safeJson(
+    body: JsValue,
+    typ: Option[String] = None
+  ): JsValue = {
+    val allFieldsToReplace = typ.flatMap(WhiteListByType.get) match {
+      case None => GlobalFieldsToReplace
+      case Some(whitelist) => GlobalFieldsToReplace.filter { name => !whitelist.contains(name) }
+    }
+
+    body match {
+      case o: JsObject => {
+        JsObject(
+          o.value.map { case (k, v) =>
+            if (allFieldsToReplace.contains(k.toLowerCase.trim)) {
+              k -> JsString("x" * stringLength(v))
+            } else {
+              k -> v
+            }
+          }
+        )
+      }
+      case a: JsArray => {
+        JsArray(
+          a.value.map { v => safeJson(v) }
+        )
+      }
+      case _ => body
+    }
+  }
+
+  private[this] def stringLength(js: JsValue): Int = {
+    js match {
+      case JsNull => 0
+      case v: JsString => v.value.length
+      case v: JsNumber => v.value.toString().length
+      case _ => js.toString().length
+    }
+  }
+}

--- a/test/lib/LoggingUtilSpec.scala
+++ b/test/lib/LoggingUtilSpec.scala
@@ -1,0 +1,43 @@
+package lib
+
+import org.scalatestplus.play._
+import play.api.libs.json._
+
+class LoggingUtilSpec extends PlaySpec with OneServerPerSuite {
+
+  "safeJson when type is not known" in {
+    LoggingUtil.safeJson(JsNull) must equal(JsNull)
+    LoggingUtil.safeJson(JsString("a")) must equal(JsString("a"))
+
+    LoggingUtil.safeJson(Json.obj("foo" -> "bar")) must equal(Json.obj("foo" -> "bar"))
+
+    LoggingUtil.safeJson(Json.obj("foo" -> "bar", "cvv" -> "123", "number" -> "1234567890")) must equal(
+      Json.obj("foo" -> "bar", "cvv" -> "xxx", "number" -> "xxxxxxxxxx")
+    )
+
+    LoggingUtil.safeJson(
+      JsArray(
+        Seq(
+          Json.obj("foo" -> "bar"),
+          Json.obj("cvv" -> "123"),
+          Json.obj("number" -> "1234567890")
+        )
+      )
+    )must equal(
+      JsArray(
+        Seq(
+          Json.obj("foo" -> "bar"),
+          Json.obj("cvv" -> "xxx"),
+          Json.obj("number" -> "xxxxxxxxxx")
+        )
+      )
+
+    )
+  }
+
+  "safeJson with type whitelist" in {
+    LoggingUtil.safeJson(Json.obj("number" -> "1234567890"), typ = Some("order_form")) must equal(
+      Json.obj("number" -> "1234567890")
+    )
+  }
+}


### PR DESCRIPTION
- debugging current validation error on client auth
  - 'cvv' and 'number' are scrubbed prior to logging for all requests,
    with support for a white list for known safe values (e.g. item and
    order number are logged, card number redacted)
  - redaction preserves length of value to aid in debugging - e.g. cvv
    of 123 will be logged as xxx