### PR TITLE
Add /_internal_/routes path to lookup a route

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ API Proxy server that is hosted at https://api.flow.io
   - Support envelope=request query parameter that allows you to POST a JSON object that we will
     use to create the request
   - Converts www form urlencoded strings (body and query for JSONP) into form data, validating
-    and converting types according to one or more apidoc schemas (via environment variable
-    named APIDOC_SERVICE_URIS)
+    and converting types according to one or more apibuilder schemas (via environment variable
+    named APIBUILDER_SERVICE_URIS)
 
 ## Bypassing proxy
 
@@ -51,19 +51,37 @@ for a user that is a member of the 'flow' organization.
 
 ## Internal URLs
 
-View current configuration, including all services and routes:
+### Healthcheck
 
 ```
-http://localhost:9000/_internal_/config
+http://localhost:7000/_internal_/healthcheck
+```
+
+### Diagnostics
+
+```
+http://localhost:7000/_internal_/diagnostics
+```
+
+### View current configuration, including all services and routes:
+
+```
+http://localhost:7000/_internal_/config
 ```
 
 ## Example configuration files
 
-environment variable | example URL
--------------------- | ---------------
-PROXY_CONFIG_URIS    | https://s3.amazonaws.com/io.flow.aws-s3-public/util/api-proxy/development.config
-APIDOC_SERVICE_URIS  | https://s3.amazonaws.com/io.flow.aws-s3-public/util/api-proxy/latest/api.service.json
+environment variable     | example URL
+------------------------ | ---------------
+PROXY_CONFIG_URIS        | https://s3.amazonaws.com/io.flow.aws-s3-public/util/api-proxy/latest/development.config.yml
+APIBUILDER_SERVICE_URIS  | https://s3.amazonaws.com/io.flow.aws-s3-public/util/api-proxy/latest/api.service.json
 
 Multiple URIS can be provided as a single, comma-separated string.
 
-[Learn more about apidoc](http://apidoc.me)
+[Learn more about API Builder](https://www.apibuilder.io)
+
+### Resolve a route
+
+```
+http://localhost:7000/_internal_/route
+```

--- a/app/controllers/RequestHandler.scala
+++ b/app/controllers/RequestHandler.scala
@@ -34,6 +34,7 @@ class Router @Inject() (
       (request.method, request.path, request.headers.get(Constants.Headers.FlowServer)) match {
         case ("GET", "/_internal_/healthcheck", None) => internal.getHealthcheck
         case ("GET", "/_internal_/config", None) => internal.getConfig
+        case ("GET", "/_internal_/route", None) => internal.getRoute()
         case ("GET", "/favicon.ico", None) => internal.favicon
         case (_, "/_internal_/diagnostics", None) => internal.diagnostics
         case ("GET", "/robots.txt", None) => internal.getRobots

--- a/app/views/footer.scala.html
+++ b/app/views/footer.scala.html
@@ -1,0 +1,7 @@
+<hr size="1"/>
+<div style="text-align:right; font-size:60%">
+  <a href="https://github.com/flowvault/proxy">API Proxy</a>
+</div>
+
+</body>
+</html>

--- a/app/views/header.scala.html
+++ b/app/views/header.scala.html
@@ -1,0 +1,7 @@
+@(title: String)
+
+<!DOCTYPE html>
+<html lang="en">
+  <title>@title</title>
+  <body>
+    <h1>@title</h1>

--- a/app/views/route.scala.html
+++ b/app/views/route.scala.html
@@ -1,0 +1,41 @@
+@(
+  path: Option[String],
+  results: Seq[controllers.RouteResult]
+)
+
+@header("Routes")
+
+<form method="GET">
+  Path: <input type="text" name="path" value="@path.getOrElse("")" />
+  <input type="submit" />
+</form>
+
+@if(path.isDefined) {
+  @if(!results.exists(_.operation.isDefined)) {
+    <em>Path is not defined</em>
+  }
+  @if(results.exists(_.operation.isDefined)) {
+    <table cellpadding="5" cellspacing="5">
+      <tr>
+        <th>Method</th>
+        <th>Path</th>
+        <th>Server</th>
+      </tr>
+
+      @results.map { r =>
+        <tr>
+          <td>@r.method</td>
+          @if(r.operation.isEmpty) {
+            <td colspan="2"><i>not defined</i></td>
+          }
+          @if(r.operation.isDefined) {
+            <td>@r.operation.get.route.path</td>
+            <td>@r.operation.get.server.name @r.operation.get.server.host</td>
+          }
+        </tr>
+      }
+    </table>
+  }
+}
+
+@footer()


### PR DESCRIPTION
- Allows us to enter a URL path and then displays all servers
    that respond to that path, including the specification path