### PR TITLE
Remove CF-RAY header from being proxied to downstream services

### DIFF
--- a/app/lib/Constants.scala
+++ b/app/lib/Constants.scala
@@ -16,7 +16,9 @@ object Constants {
     val ForwardedOrigin = "X-Forwarded-Origin"
     val ForwardedMethod = "X-Forwarded-Method"
 
-    val namesToRemove = Seq(FlowAuth, FlowRequestId, FlowServer, FlowHost, Host, Origin, ForwardedOrigin, ForwardedMethod)
+    val CfRay = "CF-RAY"
+
+    val namesToRemove = Seq(FlowAuth, FlowRequestId, FlowServer, FlowHost, Host, Origin, ForwardedOrigin, ForwardedMethod, CfRay)
   }
 
   /**


### PR DESCRIPTION
If we orange-cloud proxy, downstream services using cloudflare orange-cloud would break. See: https://support.cloudflare.com/hc/en-us/articles/200171976-Error-1000-DNS-points-to-prohibited-IP

One of the things we can try is to remove the CF-RAY header from being passed downstream. I believe this should be safe because api.flow.io is currently grey-clouded and I set up a parallel proxy url at api2.flow.io (which is orange-clouded and we can test there).