### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,11 +14,11 @@ lazy val root = project
       filters,
       ws,
       "commons-codec" % "commons-codec" % "1.10",
-      "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.210",
+      "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.213",
       "com.jason-goodwin" %% "authentikat-jwt" % "0.4.5",
       "io.flow" %% "apibuilder-validation" % "0.1.6",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test",
-      "org.yaml" % "snakeyaml" % "1.18"
+      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test",
+      "org.yaml" % "snakeyaml" % "1.19"
     )
   )
 


### PR DESCRIPTION
- com.amazonaws
    - aws-java-sdk-cloudwatch (1.11.210 => 1.11.213)
  - org.scalatestplus.play
    - scalatestplus-play (1.5.1 => 3.1.2)
  - org.yaml
    - snakeyaml (1.18 => 1.19)