### PR TITLE
Add validation when content type is url form encoded and body is JSON

### DIFF
--- a/app/handlers/ApplicationJsonHandler.scala
+++ b/app/handlers/ApplicationJsonHandler.scala
@@ -4,6 +4,7 @@ import javax.inject.{Inject, Singleton}
 
 import lib._
 import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.WSClient
 import play.api.mvc.Result
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,6 +17,7 @@ class ApplicationJsonHandler @Inject() (
 ) extends Handler {
 
   override def process(
+    wsClient: WSClient,
     server: Server,
     request: ProxyRequest,
     route: Route,
@@ -44,6 +46,7 @@ class ApplicationJsonHandler @Inject() (
 
       case Success(js) => {
         processJson(
+          wsClient,
           server,
           request,
           route,
@@ -55,6 +58,7 @@ class ApplicationJsonHandler @Inject() (
   }
 
   private[handlers] def processJson(
+    wsClient: WSClient,
     server: Server,
     request: ProxyRequest,
     route: Route,
@@ -75,6 +79,7 @@ class ApplicationJsonHandler @Inject() (
 
       case Right(validatedBody) => {
         genericHandler.process(
+          wsClient,
           server,
           request.copy(
             contentType = ContentType.ApplicationJson,

--- a/app/handlers/ApplicationJsonHandler.scala
+++ b/app/handlers/ApplicationJsonHandler.scala
@@ -63,6 +63,7 @@ class ApplicationJsonHandler @Inject() (
   )(
     implicit ec: ExecutionContext
   ): Future[Result] = {
+    println(s"JS: $js")
     apiBuilderServicesFetcher.multiService.upcast(route.method.toString, route.path, js) match {
       case Left(errors) => {
         Future.successful(

--- a/app/handlers/ApplicationJsonHandler.scala
+++ b/app/handlers/ApplicationJsonHandler.scala
@@ -63,7 +63,6 @@ class ApplicationJsonHandler @Inject() (
   )(
     implicit ec: ExecutionContext
   ): Future[Result] = {
-    println(s"JS: $js")
     apiBuilderServicesFetcher.multiService.upcast(route.method.toString, route.path, js) match {
       case Left(errors) => {
         Future.successful(

--- a/app/handlers/ApplicationJsonHandler.scala
+++ b/app/handlers/ApplicationJsonHandler.scala
@@ -78,6 +78,7 @@ class ApplicationJsonHandler @Inject() (
         genericHandler.process(
           server,
           request.copy(
+            contentType = ContentType.ApplicationJson,
             body = Some(ProxyRequestBody.Json(validatedBody))
           ),
           route,

--- a/app/handlers/GenericHandler.scala
+++ b/app/handlers/GenericHandler.scala
@@ -20,24 +20,12 @@ class GenericHandler @Inject() (
   @Named("metric-actor") val metricActor: ActorRef,
   override val config: Config,
   flowAuth: FlowAuth,
-  wsClient: WSClient,
   apiBuilderServicesFetcher: ApiBuilderServicesFetcher
 ) extends Handler with HandlerUtilities {
 
   override def multiService: MultiService = apiBuilderServicesFetcher.multiService
 
   override def process(
-    server: Server,
-    request: ProxyRequest,
-    route: Route,
-    token: ResolvedToken
-  )(
-    implicit ec: ExecutionContext
-  ): Future[Result] = {
-    process(wsClient, server, request, route, token)
-  }
-
-  private[handlers] def process(
     wsClient: WSClient,
     server: Server,
     request: ProxyRequest,

--- a/app/handlers/Handler.scala
+++ b/app/handlers/Handler.scala
@@ -1,6 +1,7 @@
 package handlers
 
 import lib.{ProxyRequest, ResolvedToken, Route, Server}
+import play.api.libs.ws.WSClient
 import play.api.mvc.Result
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -8,6 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait Handler {
 
   def process(
+    wsClient: WSClient,
     server: Server,
     request: ProxyRequest,
     route: Route,

--- a/app/handlers/JsonpHandler.scala
+++ b/app/handlers/JsonpHandler.scala
@@ -15,7 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 @Singleton
 class JsonpHandler @Inject() (
-  applicationJsonHandler: ApplicationJsonHandler
+  urlFormEncodedHandler: UrlFormEncodedHandler
 ) extends Handler {
 
   override def process(
@@ -26,12 +26,13 @@ class JsonpHandler @Inject() (
   )(
     implicit ec: ExecutionContext
   ): Future[Result] = {
-    applicationJsonHandler.processJson(
+    println(s"request.rawQueryString: ${request.rawQueryString}")
+    urlFormEncodedHandler.processUrlFormEncoded(
       server,
       request,
       route,
       token,
-      FormData.toJson(request.queryParameters)
+      request.rawQueryString
     )
   }
 

--- a/app/handlers/JsonpHandler.scala
+++ b/app/handlers/JsonpHandler.scala
@@ -4,6 +4,7 @@ import javax.inject.{Inject, Singleton}
 
 import io.apibuilder.validation.FormData
 import lib.{ProxyRequest, ResolvedToken, Route, Server}
+import play.api.libs.ws.WSClient
 import play.api.mvc.Result
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,6 +20,7 @@ class JsonpHandler @Inject() (
 ) extends Handler {
 
   override def process(
+    wsClient: WSClient,
     server: Server,
     request: ProxyRequest,
     route: Route,
@@ -27,6 +29,7 @@ class JsonpHandler @Inject() (
     implicit ec: ExecutionContext
   ): Future[Result] = {
     urlFormEncodedHandler.processUrlFormEncoded(
+      wsClient,
       server,
       request,
       route,

--- a/app/handlers/JsonpHandler.scala
+++ b/app/handlers/JsonpHandler.scala
@@ -26,7 +26,6 @@ class JsonpHandler @Inject() (
   )(
     implicit ec: ExecutionContext
   ): Future[Result] = {
-    println(s"request.rawQueryString: ${request.rawQueryString}")
     urlFormEncodedHandler.processUrlFormEncoded(
       server,
       request,

--- a/scripts/test.rb
+++ b/scripts/test.rb
@@ -65,9 +65,9 @@ assert_status(201, response)
 assert_equals(response.json['id'], id)
 org = response.json
 
-# Assume application/json if body is json
+# Return error on invalid content type - curl assumes url form encoded
 response = helpers.json_request("POST", "/token-validations", { :token => IO.read(api_key_file).strip }).execute()
-assert_status(200, response)
+assert_generic_error(response, "The content type you specified 'application/x-www-form-urlencoded' does not match the body. Please specify 'Content-type: application/json' when providing a JSON Body.")
 
 # We convert application/octet-stream to application/json
 response = helpers.json_request("POST", "/sessions/organizations/demo", {}).with_content_type("application/octet-stream").execute()

--- a/scripts/test.rb
+++ b/scripts/test.rb
@@ -65,6 +65,10 @@ assert_status(201, response)
 assert_equals(response.json['id'], id)
 org = response.json
 
+# Assume application/json if body is json
+response = helpers.json_request("POST", "/token-validations", { :token => IO.read(api_key_file).strip }).execute()
+assert_status(200, response)
+
 # We convert application/octet-stream to application/json
 response = helpers.json_request("POST", "/sessions/organizations/demo", {}).with_content_type("application/octet-stream").execute()
 assert_status(201, response)

--- a/test/handlers/GenericHandlerSpec.scala
+++ b/test/handlers/GenericHandlerSpec.scala
@@ -17,7 +17,7 @@ class GenericHandlerSpec extends HandlerBasePlaySpec {
     sim.contentType must equal(Some("application/json; charset=utf-8"))
     sim.header(Constants.Headers.FlowServer) must equal(Some(sim.server.name))
     sim.header(Constants.Headers.FlowRequestId) must equal(Some(sim.request.requestId))
-    Json.parse(sim.body) must equal(
+    sim.bodyAsJson must equal(
       Json.obj("id" -> 1)
     )
   }
@@ -47,7 +47,7 @@ class GenericHandlerSpec extends HandlerBasePlaySpec {
     sim.status must equal(201)
     sim.contentLength must equal(Some(sim.body.length))
     sim.contentType must equal(Some("application/json; charset=utf-8"))
-    Json.parse(sim.body) must equal(
+    sim.bodyAsJson must equal(
       Json.obj("id" -> 1)
     )
 
@@ -74,7 +74,7 @@ class GenericHandlerSpec extends HandlerBasePlaySpec {
     envelope.status must equal(200)
     envelope.contentLength must equal(Some(envelope.body.length))
     envelope.contentType must equal(Some("application/javascript; charset=utf-8"))
-    val js = Json.parse(envelope.body)
+    val js = envelope.bodyAsJson
     (js \ "status").as[JsNumber].value.intValue() must equal(201)
     (js \ "body").as[JsObject] must equal(Json.obj("id" -> 1))
     (js \ "headers").as[JsObject].value.keys.toSeq.sorted must equal(

--- a/test/handlers/GenericHandlerSpec.scala
+++ b/test/handlers/GenericHandlerSpec.scala
@@ -1,110 +1,17 @@
 package handlers
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Source, StreamConverters}
-import akka.util.ByteString
-import helpers.{BasePlaySpec, MockStandaloneServer}
-import lib._
+import helpers.HandlerBasePlaySpec
+import lib.{Constants, Method}
 import play.api.libs.json._
-import play.api.mvc.{Headers, Result}
 
-import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
-
-class GenericHandlerSpec extends BasePlaySpec {
+class GenericHandlerSpec extends HandlerBasePlaySpec {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
   private[this] def genericHandler = app.injector.instanceOf[GenericHandler]
 
-  private[this] case class SimulatedResponse(
-    server: Server,
-    request: ProxyRequest,
-    result: Result,
-    body: String
-  ) {
-
-    val status: Int = result.header.status
-    val contentType: Option[String] = result.body.contentType
-    val contentLength: Option[Long] = result.body.contentLength
-
-    def header(name: String): Option[String] = {
-      result.header.headers.get(name)
-    }
-
-  }
-
-  private[this] def createProxyRequest(
-    requestMethod: Method,
-    requestPath: String,
-    body: Option[ProxyRequestBody] = None,
-    queryParameters: Map[String, Seq[String]] = Map.empty,
-    headers: Map[String, Seq[String]] = Map.empty
-  ): ProxyRequest = {
-    rightOrErrors(
-      ProxyRequest.validate(
-        requestMethod = requestMethod.toString,
-        requestPath = requestPath,
-        body = body,
-        queryParameters = queryParameters,
-        headers = Headers(
-          headers.flatMap { case (k, values) =>
-            values.map { v =>
-              (k, v)
-            }
-          }.toSeq: _*
-        )
-      )
-    )
-  }
-
-  private[this] def toString(source: Source[ByteString, _]): String = {
-    implicit val system: ActorSystem = ActorSystem("toString")
-    implicit val materializer: ActorMaterializer = ActorMaterializer()
-    val is = source.runWith(StreamConverters.asInputStream(FiniteDuration(100, MILLISECONDS)))
-    scala.io.Source.fromInputStream(is, "UTF-8").mkString
-  }
-
-  private[this] def simulate(
-    method: Method,
-    path: String,
-    serverName: String = "test",
-    queryParameters: Map[String, Seq[String]] = Map.empty
-  ): SimulatedResponse = {
-    MockStandaloneServer.withTestClient { (client, port) =>
-      val server = Server(
-        name = serverName,
-        host = s"http://localhost:$port"
-      )
-
-      val proxyRequest = createProxyRequest(
-        requestMethod = method,
-        requestPath = path,
-        queryParameters = queryParameters
-      )
-
-      val result = await(
-        genericHandler.process(
-          wsClient = client,
-          server = server,
-          request = proxyRequest,
-          route = Route(method, path),
-          token = ResolvedToken(requestId = createTestId())
-        )
-      )
-
-      SimulatedResponse(
-        server = server,
-        request = proxyRequest,
-        result = result,
-        body = toString(result.body.dataStream)
-      )
-    }
-  }
-
-
   "defaults content type to application/json" in {
-    val sim = simulate(Method.Get, "/users/1")
+    val sim = simulate(genericHandler, Method.Get, "/users/1")
     sim.status must equal(200)
     sim.contentLength must equal(Some(sim.body.length))
     sim.contentType must equal(Some("application/json; charset=utf-8"))
@@ -116,7 +23,7 @@ class GenericHandlerSpec extends BasePlaySpec {
   }
 
   "propagates redirect" in {
-    val sim = simulate(Method.Get, "/redirect/example")
+    val sim = simulate(genericHandler, Method.Get, "/redirect/example")
     sim.result.header.status must equal(303)
     sim.contentLength must equal(Some(0))
     sim.header("Location") must equal(Some("http://localhost/foo"))
@@ -125,18 +32,18 @@ class GenericHandlerSpec extends BasePlaySpec {
   }
 
   "respects provided content type" in {
-    val sim = simulate(Method.Get, "/file.pdf")
+    val sim = simulate(genericHandler, Method.Get, "/file.pdf")
     sim.result.header.status must equal(200)
     sim.contentType must equal(Some("application/pdf; charset=utf-8"))
   }
 
   "propagates 404" in {
-    val sim = simulate(Method.Get, "/non-existent-path")
+    val sim = simulate(genericHandler, Method.Get, "/non-existent-path")
     sim.result.header.status must equal(404)
   }
 
   "supports jsonp" in {
-    val sim = simulate(Method.Post, "/users")
+    val sim = simulate(genericHandler, Method.Post, "/users")
     sim.status must equal(201)
     sim.contentLength must equal(Some(sim.body.length))
     sim.contentType must equal(Some("application/json; charset=utf-8"))
@@ -144,7 +51,7 @@ class GenericHandlerSpec extends BasePlaySpec {
       Json.obj("id" -> 1)
     )
 
-    val jsonp = simulate(
+    val jsonp = simulate(genericHandler, 
       Method.Post,
       "/users",
       queryParameters = Map("callback" -> Seq("foo"))
@@ -156,10 +63,10 @@ class GenericHandlerSpec extends BasePlaySpec {
   }
 
   "supports response envelope" in {
-    val sim = simulate(Method.Post, "/users")
+    val sim = simulate(genericHandler, Method.Post, "/users")
     sim.status must equal(201)
 
-    val envelope = simulate(
+    val envelope = simulate(genericHandler, 
       Method.Post,
       "/users",
       queryParameters = Map("envelope" -> Seq("response"))

--- a/test/handlers/UrlFormEncodedHandlerSpec.scala
+++ b/test/handlers/UrlFormEncodedHandlerSpec.scala
@@ -1,7 +1,7 @@
 package handlers
 
 import helpers.HandlerBasePlaySpec
-import lib.Method
+import lib.{ContentType, Method}
 import play.api.libs.json.Json
 
 class UrlFormEncodedHandlerSpec extends HandlerBasePlaySpec {
@@ -56,7 +56,10 @@ class UrlFormEncodedHandlerSpec extends HandlerBasePlaySpec {
     )
     response.status must equal(422)
     (response.bodyAsJson \ "messages").as[Seq[String]] must equal(
-      Seq("todo")
+      Seq(
+        s"The content type you specified '${ContentType.UrlFormEncoded.toString}' does not match the body. " +
+        "Please specify 'Content-type: application/json' when providing a JSON Body."
+      )
     )
   }
 }

--- a/test/handlers/UrlFormEncodedHandlerSpec.scala
+++ b/test/handlers/UrlFormEncodedHandlerSpec.scala
@@ -1,14 +1,62 @@
 package handlers
 
-import helpers.BasePlaySpec
+import helpers.HandlerBasePlaySpec
+import lib.Method
+import play.api.libs.json.Json
 
-
-class UrlFormEncodedHandlerSpec extends BasePlaySpec {
+class UrlFormEncodedHandlerSpec extends HandlerBasePlaySpec {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
   private[this] def urlFormEncodedHandler = app.injector.instanceOf[UrlFormEncodedHandler]
 
   "converts url form encoded to application/json" in {
+    val response = simulate(
+      urlFormEncodedHandler,
+      Method.Post,
+      "/users",
+      body = Some("email=joe@test.flow.io")
+    )
+    response.status must equal(201)
+    response.contentType must equal(Some("application/json; charset=utf-8"))
+    response.bodyAsJson must equal(
+      Json.obj("id" -> 1)
+    )
+  }
+
+  "validates form" in {
+    val response = simulate(
+      urlFormEncodedHandler,
+      Method.Post,
+      "/users",
+      body = Some("name=joe")
+    )
+    response.status must equal(422)
+    (response.bodyAsJson \ "messages").as[Seq[String]] must equal(
+      Seq("user_form.name must be an object and not a string")
+    )
+
+    simulate(urlFormEncodedHandler,
+      Method.Post,
+      "/users",
+      body = Some("name[first]=joe&name[last]=Smith")
+    ).status must equal(201)
+  }
+
+  "validates the content type matches the body" in {
+    val response = simulate(
+      urlFormEncodedHandler,
+      Method.Post,
+      "/users",
+      body = Some(
+        """
+          |{ "email": "joe@test.flow.io" }
+        """.stripMargin
+      )
+    )
+    response.status must equal(422)
+    (response.bodyAsJson \ "messages").as[Seq[String]] must equal(
+      Seq("todo")
+    )
   }
 }

--- a/test/handlers/UrlFormEncodedHandlerSpec.scala
+++ b/test/handlers/UrlFormEncodedHandlerSpec.scala
@@ -1,0 +1,14 @@
+package handlers
+
+import helpers.BasePlaySpec
+
+
+class UrlFormEncodedHandlerSpec extends BasePlaySpec {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  private[this] def urlFormEncodedHandler = app.injector.instanceOf[UrlFormEncodedHandler]
+
+  "converts url form encoded to application/json" in {
+  }
+}

--- a/test/helpers/HandlerBasePlaySpec.scala
+++ b/test/helpers/HandlerBasePlaySpec.scala
@@ -1,0 +1,105 @@
+package helpers
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Source, StreamConverters}
+import akka.util.ByteString
+import handlers.Handler
+import lib._
+import play.api.mvc.{Headers, Result}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+
+trait HandlerBasePlaySpec extends BasePlaySpec {
+
+  case class SimulatedResponse(
+    server: Server,
+    request: ProxyRequest,
+    result: Result,
+    body: String
+  ) {
+
+    val status: Int = result.header.status
+    val contentType: Option[String] = result.body.contentType
+    val contentLength: Option[Long] = result.body.contentLength
+
+    def header(name: String): Option[String] = {
+      result.header.headers.get(name)
+    }
+
+  }
+
+  def createProxyRequest(
+    requestMethod: Method,
+    requestPath: String,
+    body: Option[ProxyRequestBody] = None,
+    queryParameters: Map[String, Seq[String]] = Map.empty,
+    headers: Map[String, Seq[String]] = Map.empty
+  ): ProxyRequest = {
+    rightOrErrors(
+      ProxyRequest.validate(
+        requestMethod = requestMethod.toString,
+        requestPath = requestPath,
+        body = body,
+        queryParameters = queryParameters,
+        headers = Headers(
+          headers.flatMap { case (k, values) =>
+            values.map { v =>
+              (k, v)
+            }
+          }.toSeq: _*
+        )
+      )
+    )
+  }
+
+   private[this] def toString(source: Source[ByteString, _]): String = {
+    implicit val system: ActorSystem = ActorSystem("toString")
+    implicit val materializer: ActorMaterializer = ActorMaterializer()
+    val is = source.runWith(StreamConverters.asInputStream(FiniteDuration(100, MILLISECONDS)))
+    scala.io.Source.fromInputStream(is, "UTF-8").mkString
+  }
+
+   def simulate(
+    handler: Handler,
+    method: Method,
+    path: String,
+    serverName: String = "test",
+    queryParameters: Map[String, Seq[String]] = Map.empty
+  )(
+   implicit ec: ExecutionContext
+  ): SimulatedResponse = {
+    MockStandaloneServer.withTestClient { (client, port) =>
+      val server = Server(
+        name = serverName,
+        host = s"http://localhost:$port"
+      )
+
+      val proxyRequest = createProxyRequest(
+        requestMethod = method,
+        requestPath = path,
+        queryParameters = queryParameters
+      )
+
+      val result = await(
+        handler.process(
+          wsClient = client,
+          server = server,
+          request = proxyRequest,
+          route = Route(method, path),
+          token = ResolvedToken(requestId = createTestId())
+        )
+      )
+
+      SimulatedResponse(
+        server = server,
+        request = proxyRequest,
+        result = result,
+        body = toString(result.body.dataStream)
+      )
+    }
+  }
+
+
+}


### PR DESCRIPTION
- Normalize json p to use standard url form encoded handler
  - Fixes #62