### PR TITLE
Retrieve response body safely

### DIFF
--- a/app/handlers/GenericHandler.scala
+++ b/app/handlers/GenericHandler.scala
@@ -13,6 +13,7 @@ import play.api.http.HttpEntity
 import play.api.libs.json.{JsObject, JsValue}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.mvc.{Headers, Result, Results}
+import WSReponseUtil._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -136,7 +137,7 @@ class GenericHandler @Inject() (
       )
 
       if (request.responseEnvelope || response.status == 422) {
-        request.response(response.status, response.body, contentType, responseHeaders)
+        request.response(response.status, response.safeBody, contentType, responseHeaders)
       } else {
         contentLength match {
           case None => {
@@ -272,7 +273,7 @@ class GenericHandler @Inject() (
 
       case 422 => {
         // common validation error - TODO: Show body
-        " body:" + response.body
+        " body:" + response.safeBody
       }
 
       case _ => {

--- a/app/lib/WSReponseUtil.scala
+++ b/app/lib/WSReponseUtil.scala
@@ -1,0 +1,23 @@
+package lib
+
+import play.api.Logger
+import play.api.libs.ws.WSResponse
+
+import scala.util.{Failure, Success, Try}
+
+object WSReponseUtil {
+
+  private def EmptyBody = ""
+
+  implicit class WSReponseWrapper(val response: WSResponse) extends AnyVal {
+    def safeBody: String = {
+      Try(response.body) match {
+        case Success(b) => b
+        case Failure(e) =>
+          Logger.warn("Error while retrieving response body. Returning empty body.", e)
+          EmptyBody
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Simply wraps the body retrieval to avoid errors in case the body is from a `StreamedResponse`.

A better way is to do it analogously to https://github.com/flowvault/proxy/pull/244 but this PR will avoid errors in the meantime.
