### PR TITLE
Increase play.server.netty.maxInitialLineLength to allow for longer URIS

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -2,7 +2,7 @@ play.i18n.langs=["en"]
 
 evolutionplugin=disabled
 
-play.server.netty.maxInitialLineLength=8192
+play.server.netty.maxInitialLineLength=16384
 
 play.http.requestHandler = "controllers.RequestHandler"
 play.http.secret.key = ${?CONF_PLAY_CRYPTO_SECRET}


### PR DESCRIPTION
Intended to help resolve: `414: URI length exceeds the configured limit of 2048 characters`