### PR TITLE
Preserve token organization when authorizing

### DIFF
--- a/app/auth/OrganizationAuth.scala
+++ b/app/auth/OrganizationAuth.scala
@@ -46,7 +46,6 @@ trait OrganizationAuth {
     authFuture.map { orgAuth =>
       Some(
         token.copy(
-          organizationId = Some(organization),
           environment = Some(orgAuth.environment.toString),
           role = Some(orgAuth.role.toString)
         )


### PR DESCRIPTION
Currently, a user with a production token for any org can use the same token to access resources for a different organization. As long as a production token exists, the organization is overwritten with the organization from the path.

Tests to follow soon.