### PR TITLE
Don't proxy requests for 'null' 'undefined'

### DIFF
--- a/app/auth/SessionAuth.scala
+++ b/app/auth/SessionAuth.scala
@@ -3,7 +3,7 @@ package auth
 import io.flow.organization.v0.interfaces.{Client => OrganizationClient}
 import io.flow.session.v0.{Client => SessionClient}
 import io.flow.session.v0.models._
-import lib.{FlowAuth, ResolvedToken}
+import lib.{Constants, FlowAuth, ResolvedToken}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -16,74 +16,84 @@ trait SessionAuth extends LoggingHelper {
   def organizationClient: OrganizationClient
   def sessionClient: SessionClient
 
-  private[this] val Undefined = "undefined"
-
   def resolveSession(
     requestId: String,
     sessionId: String
   ) (
     implicit ec: ExecutionContext
   ): Future[Option[ResolvedToken]] = {
-    if (sessionId == Undefined) {
-      // javascript sending in 'undefined' as session id
+    if (Constants.StopWords.contains(sessionId)) {
+      // javascript sending in 'undefined' or 'null' as session id
       Future.successful(None)
     } else {
-      sessionClient.sessionAuthorizations.post(
-        SessionAuthorizationForm(session = sessionId),
-        requestHeaders = FlowAuth.headersFromRequestId(requestId)
-      ).map {
-        case auth: OrganizationSessionAuthorization => {
-          Some(
-            ResolvedToken(
-              requestId = requestId,
-              userId = None,
-              environment = Some(auth.environment),
-              organizationId = Some(auth.organization.id),
-              partnerId = None,
-              role = None,
-              sessionId = Some(sessionId)
-            )
+      doResolveSession(
+        requestId = requestId,
+        sessionId = sessionId
+      )
+    }
+  }
+
+  private[this] def doResolveSession(
+    requestId: String,
+    sessionId: String
+  ) (
+    implicit ec: ExecutionContext
+  ): Future[Option[ResolvedToken]] = {
+    sessionClient.sessionAuthorizations.post(
+      SessionAuthorizationForm(session = sessionId),
+      requestHeaders = FlowAuth.headersFromRequestId(requestId)
+    ).map {
+      case auth: OrganizationSessionAuthorization => {
+        Some(
+          ResolvedToken(
+            requestId = requestId,
+            userId = None,
+            environment = Some(auth.environment),
+            organizationId = Some(auth.organization.id),
+            partnerId = None,
+            role = None,
+            sessionId = Some(sessionId)
           )
-        }
+        )
+      }
 
-        case SessionAuthorizationUndefinedType(other) => {
-          log(requestId).
-            withKeyValue("session_id", sessionId).
-            withKeyValue("type", other).
-            warn("SessionAuthorizationUndefinedType")
-          None
-        }
-      }.recover {
-        case io.flow.organization.v0.errors.UnitResponse(code) => {
-          log(requestId).
-            withKeyValue("http_status_code", code).
-            withKeyValue("session_id", sessionId).
-            warn("Unexpected HTTP Status Code - request will not be authorized")
-          None
-        }
+      case SessionAuthorizationUndefinedType(other) => {
+        log(requestId).
+          withKeyValue("session_id", sessionId).
+          withKeyValue("type", other).
+          warn("SessionAuthorizationUndefinedType")
+        None
+      }
+    }.recover {
+      case io.flow.organization.v0.errors.UnitResponse(code) => {
+        log(requestId).
+          withKeyValue("http_status_code", code).
+          withKeyValue("session_id", sessionId).
+          warn("Unexpected HTTP Status Code - request will not be authorized")
+        None
+      }
 
-        case e: io.flow.session.v0.errors.GenericErrorResponse => {
-          e.genericError.messages.mkString(", ") match {
-            case "Session does not exist" => // expected - don't log
-            case _ => {
-              log(requestId).
-                withKeyValue("http_status_code", "422").
-                withKeyValue("session_id", sessionId).
-                withKeyValues("message", e.genericError.messages).
-                warn("422 authorizing session")
-            }
+      case e: io.flow.session.v0.errors.GenericErrorResponse => {
+        e.genericError.messages.mkString(", ") match {
+          case "Session does not exist" => // expected - don't log
+          case _ => {
+            log(requestId).
+              withKeyValue("http_status_code", "422").
+              withKeyValue("session_id", sessionId).
+              withKeyValues("message", e.genericError.messages).
+              warn("422 authorizing session")
           }
-
-          None
         }
 
-        case ex: Throwable => {
-          val msg = "Error communication with session service"
-          log(requestId).
-            withKeyValue("session_id", sessionId).
-            error(msg, ex)
-          throw new RuntimeException(msg, ex)
-        }
+        None
+      }
+
+      case ex: Throwable => {
+        val msg = "Error communication with session service"
+        log(requestId).
+          withKeyValue("session_id", sessionId).
+          error(msg, ex)
+        throw new RuntimeException(msg, ex)
       }
     }
   }

--- a/app/auth/TokenAuth.scala
+++ b/app/auth/TokenAuth.scala
@@ -2,7 +2,7 @@ package auth
 
 import io.flow.token.v0.interfaces.Client
 import io.flow.token.v0.models._
-import lib.{FlowAuth, ResolvedToken}
+import lib.{Constants, FlowAuth, ResolvedToken}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -15,6 +15,23 @@ trait TokenAuth extends LoggingHelper {
   def tokenClient: Client
 
   def resolveToken(
+    requestId: String,
+    token: String
+  )(
+    implicit ec: ExecutionContext
+  ): Future[Option[ResolvedToken]] = {
+    if (Constants.StopWords.contains(token)) {
+      // javascript sending in 'undefined' or 'null' as session id
+      Future.successful(None)
+    } else {
+      doResolveToken(
+        requestId = requestId,
+        token = token
+      )
+    }
+  }
+
+  private[this] def doResolveToken(
     requestId: String,
     token: String
   )(

--- a/app/lib/Constants.scala
+++ b/app/lib/Constants.scala
@@ -2,6 +2,8 @@ package lib
 
 object Constants {
 
+  val StopWords = Set("undefined", "null")
+
   object Headers {
 
     val FlowAuth = "X-Flow-Auth"


### PR DESCRIPTION
- Seeing 401s in production where we forward a request for, eg:

```
$ curl -i https://api.flow.io/null/countries/destinations
HTTP/2 401
```