### PR TITLE
WIP: Add capability of switching between DNS hosts for services

### DIFF
--- a/app/controllers/ReverseProxy.scala
+++ b/app/controllers/ReverseProxy.scala
@@ -371,7 +371,7 @@ class ReverseProxy @Inject () (
                           method = request.method,
                           path = path
                         ),
-                        server = Server(name = "override", host = host, logger = logger)
+                        server = Server(name = "override", host = host, newHost = None, logger = logger)
                       )
                     )
                   } else {

--- a/app/handlers/GenericHandler.scala
+++ b/app/handlers/GenericHandler.scala
@@ -88,7 +88,11 @@ class GenericHandler @Inject() (
     route: Route,
     token: ResolvedToken
   ): WSRequest = {
-    wsClient.url(server.host + request.path)
+    // TODO add dynamic switch here so we can turn off usage of all new hosts altogether dynamically very quickly
+    val host = server.newHost
+      .getOrElse(server.host)
+
+    wsClient.url(host + request.path)
       .withFollowRedirects(false)
       .withMethod(route.method.toString)
       .withRequestTimeout(server.requestTimeout)

--- a/app/lib/ConfigParser.scala
+++ b/app/lib/ConfigParser.scala
@@ -56,6 +56,7 @@ class ConfigParser @Inject() (
             InternalServer(
               name = getString(obj, "name"),
               host = getString(obj, "host"),
+              newHost = obj.get("new_host").map(_.toString.trim),
               logger = serverLogger
             )
           }

--- a/app/lib/ProxyConfigFetcher.scala
+++ b/app/lib/ProxyConfigFetcher.scala
@@ -102,7 +102,8 @@ case class InternalProxyConfig(
 case class Server(
   name: String,
   host: String,
-  logger: RollbarLogger
+  logger: RollbarLogger,
+  newHost: Option[String] = None
 ) {
 
   // TODO: Move to proxy configuration file
@@ -128,6 +129,7 @@ case class Operation(
 case class InternalServer(
   name: String,
   host: String,
+  newHost: Option[String],
   logger: RollbarLogger
 ) {
 
@@ -139,7 +141,8 @@ case class InternalServer(
         Server(
           name = name,
           host = host,
-          logger
+          logger = logger,
+          newHost = newHost
         )
       )
     }


### PR DESCRIPTION
This is one possibility for introducing a way to switch between hosts and would allow us to adopt Kubernetes incrementally with the capability to switch back quickly.

The thought is as we transition services to kubernetes we first launch them on a new domain (e.g. *.svc.flow.io), then update the Proxy configuration to use the new domain on a per-service bases once we've launched the given service on the Kubernetes cluster. Once we've transitioned to kubernetes we can remove this feature and switch DNS back to *.api.flow.io.

This is still in progress as we require some way to quickly turn off the usage of all new domains (see: [this line](https://github.com/flowvault/proxy/compare/kubernetes_switch?expand=1#diff-c8e333ee7a39b7387261175d1bbf2dd8R91)) dynamically, such as using a flag from the features service or a new internal proxy endpoint?