### PR TITLE
Add logging config for max log file size and number files kept

### DIFF
--- a/deploy-proxy.sh
+++ b/deploy-proxy.sh
@@ -19,4 +19,4 @@ set -x #echo on
 docker stop `docker ps -q`;
 docker rmi -f `docker images -q`;
 docker rm $(docker ps -qa --no-trunc --filter "status=exited")
-docker run -d -p 7000:9000 flowvault/proxy:$1 production;
+docker run --log-opt max-size=1g --log-opt max-file=10 -d -p 7000:9000 flowvault/proxy:$1 production;


### PR DESCRIPTION
We regularly run out of space per container run now on the proxy instances because we are simply logging too much. Adding this should ensure we keep a sane number of logs around without exhausting storage on the ec2 instance.