### PR TITLE
Increase max size of request to accomodate for large files

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -2,6 +2,11 @@ play.i18n.langs=["en"]
 
 evolutionplugin=disabled
 
+# see: https://stackoverflow.com/questions/36283702/playframework-2-4-6-error-413-request-entity-too-large
+# here to address large import files, such as: https://app.clubhouse.io/flow/story/16482/imports-improve-error-for-too-large-files
+play.http.parser.maxDiskBuffer = 100MB
+parsers.anyContent.maxLength = 100MB
+
 play.server.netty.maxInitialLineLength=16384
 akka.http.parsing.max-uri-length = 16k
 


### PR DESCRIPTION
Addresses issue of having large customs descriptions input file: https://app.clubhouse.io/flow/story/16482/imports-improve-error-for-too-large-files

Solution found here: https://stackoverflow.com/questions/36283702/playframework-2-4-6-error-413-request-entity-too-large