### PR TITLE
Increase max content length for json payload from 100KB to 5MB

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -6,6 +6,7 @@ evolutionplugin=disabled
 # here to address large import files, such as: https://app.clubhouse.io/flow/story/16482/imports-improve-error-for-too-large-files
 play.http.parser.maxDiskBuffer = 100MB
 parsers.anyContent.maxLength = 100MB
+play.http.parser.maxMemoryBuffer = 5MB
 
 play.server.netty.maxInitialLineLength=16384
 akka.http.parsing.max-uri-length = 16k


### PR DESCRIPTION
See https://www.playframework.com/documentation/2.6.x/ScalaBodyParsers