### PR TITLE
Config: Enable migration away from comma to space for separator

### DIFF
--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -11,7 +11,7 @@ class Config @Inject() (
   private[this] object Names {
     val JwtSalt = "jwt.salt"
     val VerboseLogPrefixes = "integration.path.prefixes"
-    val Required = Seq(JwtSalt)
+    val Required: Seq[String] = Seq(JwtSalt)
   }
 
   lazy val jwtSalt: String = requiredString(Names.JwtSalt)
@@ -41,4 +41,21 @@ class Config @Inject() (
     }
   }
 
+  def requiredList(name: String): List[String] = {
+    val value = requiredString(name)
+    value.split(delim(value)).map(_.trim).toList
+  }
+
+  /**
+    * Migrating from comma to space as delimiter due to a bug
+    * in our dev tools
+    */
+  private[this] def delim(str: String): String = {
+    val i = str.indexOf(",")
+    if (i > 0) {
+      ","
+    } else {
+      " "
+    }
+  }
 }

--- a/app/lib/ProxyConfigFetcher.scala
+++ b/app/lib/ProxyConfigFetcher.scala
@@ -195,7 +195,7 @@ class ProxyConfigFetcher @Inject() (
   logger: RollbarLogger
 ) {
 
-  private[this] lazy val Uris: Seq[String] = config.requiredString("proxy.config.uris").split(",").map(_.trim)
+  private[this] lazy val Uris: List[String] = config.requiredList("proxy.config.uris")
 
   /**
     * Loads proxy configuration from the specified URIs


### PR DESCRIPTION
- Our 'dev' script has a bug that is losing all config values after first comma
 - Fix is not simple - migrate config here to use space to allow editing config
   safely