### PR TITLE
Remove start and done logging

### DIFF
--- a/app/handlers/GenericHandler.scala
+++ b/app/handlers/GenericHandler.scala
@@ -39,6 +39,8 @@ class GenericHandler @Inject() (
       case ProxyRequestBody.Bytes(_) => "bytes"
       case ProxyRequestBody.File(_) => "file"
     }
+    log(request, server, "start", Map("body" -> body.getOrElse("-")))
+
     val wsRequest = buildRequest(wsClient, server, request, route, token)
 
     request.body match {
@@ -250,6 +252,12 @@ class GenericHandler @Inject() (
         }.getOrElse(Map.empty[String, String])
       }
     }
+
+    log(request, server, "done", extra ++ Map(
+      "status" -> response.status.toString,
+      "timeToFirstByteMs" -> duration.toString,
+      "response.contentLength" -> response.header("Content-Length").getOrElse("-")
+    ))
   }
 
   private[this] def isSessionAuth(value: String): Boolean = {

--- a/app/handlers/GenericHandler.scala
+++ b/app/handlers/GenericHandler.scala
@@ -39,8 +39,6 @@ class GenericHandler @Inject() (
       case ProxyRequestBody.Bytes(_) => "bytes"
       case ProxyRequestBody.File(_) => "file"
     }
-    log(request, server, "start", Map("body" -> body.getOrElse("-")))
-
     val wsRequest = buildRequest(wsClient, server, request, route, token)
 
     request.body match {
@@ -252,12 +250,6 @@ class GenericHandler @Inject() (
         }.getOrElse(Map.empty[String, String])
       }
     }
-
-    log(request, server, "done", extra ++ Map(
-      "status" -> response.status.toString,
-      "timeToFirstByteMs" -> duration.toString,
-      "response.contentLength" -> response.header("Content-Length").getOrElse("-")
-    ))
   }
 
   private[this] def isSessionAuth(value: String): Boolean = {


### PR DESCRIPTION
Start and done logging are valuable in a pinch when diagnosing timed out requests but practically they produce a ton of data that usually doesn't tell us any more than access logs. Something like 25% of our total log volume is these two categories.

Should we encounter new timeouts, re-introducing this logging may be required. At that time we should probably introduce a feature so we can control the output of these data.