### PR TITLE
Attempt for better grouping and reporting of proxy ServerErrors

### DIFF
--- a/app/lib/ErrorHandler.scala
+++ b/app/lib/ErrorHandler.scala
@@ -31,13 +31,13 @@ class ErrorHandler @Inject() (
 
   def onServerError(request: RequestHeader, ex: Throwable): Future[Result] = {
     val errorLogger = rollbarLogger(request)
-    errorLogger.logger.error("ServerError", ex)
+    errorLogger.logger.error(s"ServerError: ${ex.getMessage}", ex)
 
     val r = InternalServerError(serverErrors(Seq(s"A server error occurred (err #${errorLogger.errorId})")))
     Future.successful(r)
   }
 
-  private[this] def rollbarLogger(request: RequestHeader): ErrorLogger = {
+  private[this] def rollbarLogger(request: RequestHeader, ex: Option[Throwable] = None): ErrorLogger = {
     val operation = index.resolve(Method(request.method), request.uri)
     val errorId = generateErrorId()
     val baseLogger = operation.map(_.server.logger).getOrElse(defaultLogger)
@@ -46,9 +46,18 @@ class ErrorHandler @Inject() (
     val headerKeys = request.headers.keys.toSeq
     val headers = Util.filterKeys(request.headers.toMap, Constants.Headers.namesToWhitelist)
 
+    // attempt better grouping of errors
+    val fingerprint = Seq(
+      ex.map(_.getClass.getName),
+      Some(request.method.toString),
+      operation.map(_.route.path),
+      operation.map(_.server.host)
+    ).flatten.mkString
+
     ErrorLogger(
       errorId,
       baseLogger.
+        fingerprint(fingerprint).
         withKeyValue("error_id", errorId).
         withKeyValue("request_ip", request.remoteAddress).
         withKeyValue("request_method", request.method.toString).

--- a/app/lib/ErrorHandler.scala
+++ b/app/lib/ErrorHandler.scala
@@ -50,8 +50,8 @@ class ErrorHandler @Inject() (
     val fingerprint = Seq(
       ex.map(_.getClass.getName),
       Some(request.method.toString),
-      operation.map(_.route.path),
-      operation.map(_.server.host)
+      operation.map(_.server.host),
+      operation.map(_.route.path)
     ).flatten.mkString
 
     ErrorLogger(


### PR DESCRIPTION
Currently, it is difficult to tell what proxy's `ServerError`s are in rollbar, for example:

https://rollbar.com/flow.io/proxy/items/97/
https://rollbar.com/flow.io/proxy/items/94/
https://rollbar.com/flow.io/proxy/items/100/
https://rollbar.com/flow.io/proxy/items/89/
https://rollbar.com/flow.io/proxy/items/87/

Most of them appear to be timeouts accumulated over multiple services, when it could be more useful is proxy groups them by service and even by request type - it would have been easier to troubleshoot and see trends across different errors.