### PR TITLE
Allow Googlebot l10n client sites

### DIFF
--- a/app/controllers/Internal.scala
+++ b/app/controllers/Internal.scala
@@ -38,14 +38,11 @@ class Internal @Inject() (
   )
 
   /**
-    robots.txt Notes
-    -------------------
-
-    Googlebot white-listed URLs are here to allow their crawler access our API during client page-load.
-    These endpoints are consumed by Shopify/FlowJS. This allow Google to crawl our clients sites and
-    localize prices (and more importantly schema data) so as allow l10n'd structured data for localized
-    adverts.
-  */
+   * Googlebot white-listed URLs are here to allow their crawler to access our API during client page-load.
+   * These endpoints are consumed by Shopify/FlowJS. This allow Google to crawl our clients sites and
+   * localize prices (and more importantly schema data) so as to allow localized structured data for
+   * localized adverts.
+   */
   private[this] val RobotsTxt = """
     |User-agent: *
     |Disallow: /

--- a/app/controllers/Internal.scala
+++ b/app/controllers/Internal.scala
@@ -37,12 +37,25 @@ class Internal @Inject() (
     "status" -> "healthy"
   )
 
+  /**
+    robots.txt Notes
+    -------------------
+
+    Googlebot white-listed URLs are here to allow their crawler access our API during client page-load.
+    These endpoints are consumed by Shopify/FlowJS. This allow Google to crawl our clients sites and
+    localize prices (and more importantly schema data) so as allow l10n'd structured data for localized
+    adverts.
+  */
   private[this] val RobotsTxt = """
     |User-agent: *
     |Disallow: /
     |
     |User-agent: Googlebot
     |Allow: /shopify/shops/*/sessions
+    |Allow: /sessions/
+    |Allow: /*/bundles/browser
+    |Allow: /*/shopify/localized/variants/experience/
+    |Allow: /*/experiences/*/items/query
     |Disallow: /
     |""".stripMargin.trim
 


### PR DESCRIPTION
After the initial change yesterday it is clear we need more URLs whitelisted to allow Google have a chance to l10n the page data and hence produce the l10n'd schema data correctly.

This should be sufficient to allow Googlebot l10n pages on Shopify and other FlowJS client sites.

Googlebot errors were surfaced via this tool when attempting to text structured (schema.org) data on the page with l10n'd data.. https://search.google.com/test/rich-results?url=https%3A%2F%2Fshopify.flow.io%2Fcollections%2Ffrontpage%2Fproducts%2Focean-blue-shirt%3Fflow_country%3Dfra&user_agent=2

<img width="732" alt="image" src="https://user-images.githubusercontent.com/374591/78118111-6add5900-73fe-11ea-9cda-b1daad3563be.png">
