### PR TITLE
Add timing headers

### DIFF
--- a/app/handlers/HandlerUtilities.scala
+++ b/app/handlers/HandlerUtilities.scala
@@ -5,41 +5,12 @@ import io.flow.log.RollbarLogger
 import lib._
 import play.api.libs.json.{JsValue, Json}
 
-import scala.util.{Failure, Success, Try}
-
 trait HandlerUtilities extends Errors {
 
   def config: Config
   def logger: RollbarLogger
 
   def multiService: MultiService
-
-  def log4xx(request: ProxyRequest, status: Int, body: String): Unit = {
-    // GET too noisy due to bots
-    if (request.method != Method.Get && status >= 400 && status < 500) {
-      val finalBody = Try {
-        Json.parse(body)
-      } match {
-        case Success(js) => toLogValue(request, js, typ = None)
-        case Failure(_) => body
-      }
-
-      request.log.
-        fingerprint("Proxy4xx").
-        withKeyValue("status", status).
-        withKeyValue("body", finalBody.toString).
-        info(s"[proxy $request] responded with status:$status")
-    }
-  }
-
-  def log4xx(request: ProxyRequest, status: Int, js: JsValue, errors: Seq[String]): Unit = {
-    // GET too noisy due to bots
-    if (request.method != Method.Get && status >= 400 && status < 500) {
-      // TODO: PARSE TYPE
-      val finalBody = toLogValue(request, js, typ = None)
-      logger.info(s"[proxy $request] responded with status:$status Invalid JSON: ${errors.mkString(", ")} BODY: $finalBody")
-    }
-  }
 
   def toLogValue(
     request: ProxyRequest,

--- a/app/lib/Constants.scala
+++ b/app/lib/Constants.scala
@@ -21,6 +21,8 @@ object Constants {
     val FlowServer = "X-Flow-Server"
     val FlowHost = "X-Flow-Host"
     val FlowIp = "X-Flow-Ip"
+    val FlowProxyResponseTime = "X-Flow-Proxy-Response-Time"
+    val FlowProxyServiceTiming = "X-Flow-Proxy-Service-Timing"
 
     val ContentType = "Content-Type"
     val ContentLength = "Content-Length"

--- a/app/lib/ProxyRequest.scala
+++ b/app/lib/ProxyRequest.scala
@@ -147,8 +147,6 @@ case class ProxyRequest(
     "api" + UUID.randomUUID.toString.replaceAll("-", "") // make easy to cut & paste
   }
 
-  val createdAtMillis: Long = System.currentTimeMillis()
-
   /**
     * path is everything up to the ? - e.g. /users/
     */

--- a/app/lib/timed/TimedFuture.scala
+++ b/app/lib/timed/TimedFuture.scala
@@ -1,0 +1,15 @@
+package lib.timed
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object TimedFuture {
+  def apply[T](f: => Future[T])(implicit ec: ExecutionContext): Future[Timed[T]] = {
+    val issuedAt = System.nanoTime()
+    f.map(Timed(_, issuedAt, System.nanoTime()))
+  }
+}
+
+case class Timed[T](value: T, issuedAt: Long, completedAt: Long) {
+  lazy val durationNs: Long = completedAt - issuedAt
+  lazy val durationMs: Long = durationNs / 1000000
+}

--- a/test/controllers/HealthchecksSpec.scala
+++ b/test/controllers/HealthchecksSpec.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import helpers.BasePlaySpec
+import lib.Constants
+import org.scalatest.OptionValues
 
-class HealthchecksSpec extends BasePlaySpec {
+class HealthchecksSpec extends BasePlaySpec with OptionValues {
 
   "GET /_internal_/healthcheck" in {
     val result = await(
@@ -10,6 +12,7 @@ class HealthchecksSpec extends BasePlaySpec {
     )
     result.status must equal(200)
     result.body.contains("healthy") must equal(true)
+    result.header(Constants.Headers.FlowProxyResponseTime).value must fullyMatch regex "\\d+"
   }
 
 }


### PR DESCRIPTION
This PR introduces new response headers to all requests:

 - `X-Flow-Proxy-Response-Time`: the total time in ms it took to process the request
 - `X-Flow-Proxy-Service-Timing`: the name and response time in ms for a service. E.g., bundle-checkout;414

### Verification plan

 - [ ] New headers are present on each successful calls
 - [ ] Other headers are unchanged