### PR TITLE
CORE-2263: Send all traces to zipkin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val root = project
       "com.pauldijou" %% "jwt-play-json" % "4.3.0",
       "commons-codec" % "commons-codec" % "1.15",
       "io.apibuilder" %% "apibuilder-validation" % "0.4.21",
-      "io.flow" %% "lib-play-graphite-play28" % "0.1.83",
+      "io.flow" %% "lib-play-graphite-play28" % "0.1.87",
       "io.flow" %% "lib-usage-play28" % "0.1.15",
       "org.typelevel" %% "cats-core" % "2.3.1",
       "org.yaml" % "snakeyaml" % "1.27",

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val root = project
       "com.pauldijou" %% "jwt-play-json" % "4.3.0",
       "commons-codec" % "commons-codec" % "1.15",
       "io.apibuilder" %% "apibuilder-validation" % "0.4.21",
-      "io.flow" %% "lib-play-graphite-play28" % "0.1.87-zipkin5",
+      "io.flow" %% "lib-play-graphite-play28" % "0.1.88",
       "io.flow" %% "lib-usage-play28" % "0.1.15",
       "org.typelevel" %% "cats-core" % "2.3.1",
       "org.yaml" % "snakeyaml" % "1.27",

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val root = project
       "com.pauldijou" %% "jwt-play-json" % "4.3.0",
       "commons-codec" % "commons-codec" % "1.15",
       "io.apibuilder" %% "apibuilder-validation" % "0.4.21",
-      "io.flow" %% "lib-play-graphite-play28" % "0.1.36",
+      "io.flow" %% "lib-play-graphite-play28" % "0.1.83",
       "io.flow" %% "lib-usage-play28" % "0.1.15",
       "org.typelevel" %% "cats-core" % "2.3.1",
       "org.yaml" % "snakeyaml" % "1.27",

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val root = project
       "com.pauldijou" %% "jwt-play-json" % "4.3.0",
       "commons-codec" % "commons-codec" % "1.15",
       "io.apibuilder" %% "apibuilder-validation" % "0.4.21",
-      "io.flow" %% "lib-play-graphite-play28" % "0.1.87",
+      "io.flow" %% "lib-play-graphite-play28" % "0.1.87-zipkin5",
       "io.flow" %% "lib-usage-play28" % "0.1.15",
       "org.typelevel" %% "cats-core" % "2.3.1",
       "org.yaml" % "snakeyaml" % "1.27",

--- a/conf/application.production.conf
+++ b/conf/application.production.conf
@@ -6,3 +6,4 @@ kamon.zipkin = {
   password = ${?ZIPKIN_PASSWORD}
   url = "https://zipkin-auth-proxy.api.flow.io/api/v2/spans"
 }
+kamon.modules.zipkin-reporter.enabled = true

--- a/conf/application.production.conf
+++ b/conf/application.production.conf
@@ -1,3 +1,8 @@
 include "base.conf"
 include "/flow-metrics.conf"
 
+kamon.zipkin = {
+  username = "submit"
+  password = ${?ZIPKIN_PASSWORD}
+  url = "https://zipkin-auth-proxy.api.flow.io/api/v2/spans"
+}


### PR DESCRIPTION
The purpose of this PR is to send all traces as instrumented by Kamon to Flow's zipkin instance. This will allow us to view all intra-service API calls for a given external API call, as identified by the `trace-id` header.

Kamon collects traces of all HTTP calls (incoming and outgoing), actor messages, and database queries. No HTTP headers, bodies, or DB query parameters are collected. https://kamon.io/docs/latest/instrumentation/

Flow's zipkin instance is at https://zipkin.flo.pub