### PR TITLE
Add operation names to traces

### DIFF
--- a/app/controllers/RequestHandler.scala
+++ b/app/controllers/RequestHandler.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import kamon.Kamon
+
 import javax.inject.Inject
 import lib.Constants
 import play.api.OptionalDevContext
@@ -39,6 +41,10 @@ class Router @Inject() (
 
   override def routes = new AbstractPartialFunction[RequestHeader, Handler] {
     override def applyOrElse[A <: RequestHeader, B >: Handler](request: A, default: A => B) = {
+      val span = Kamon.currentSpan()
+      span.name(request.path)
+      span.takeSamplingDecision()
+
       (request.method, request.path, request.headers.get(Constants.Headers.FlowServer)) match {
         case ("GET", "/_internal_/healthcheck", None) => internal.getHealthcheck
         case ("GET", "/_internal_/healthcheck/checkout", None) => internal.getHealthcheckCheckout

--- a/app/controllers/ReverseProxy.scala
+++ b/app/controllers/ReverseProxy.scala
@@ -8,6 +8,8 @@ import io.flow.log.RollbarLogger
 import io.flow.organization.v0.{Client => OrganizationClient}
 import io.flow.session.v0.{Client => SessionClient}
 import io.flow.token.v0.{Client => TokenClient}
+import kamon.Kamon
+
 import javax.inject.{Inject, Singleton}
 import lib._
 import play.api.mvc._
@@ -103,6 +105,7 @@ class ReverseProxy @Inject () (
       }
 
       case Some(route) => {
+        Kamon.currentSpan().name(s"${route.route.method}-${route.route.path}")
         internalHandleValid(request, route)
       }
     }


### PR DESCRIPTION
Kamon only works with play's generated routes, so we have to do this manually.

based on https://github.com/kamon-io/kamon/blob/master/instrumentation/kamon-play/src/main/scala/kamon/instrumentation/play/PlayServerInstrumentation.scala#L252-L254