### PR TITLE
CORE-2572: Resolve warning for "Explicitly set HTTP header"

### DIFF
--- a/app/handlers/GenericHandler.scala
+++ b/app/handlers/GenericHandler.scala
@@ -148,10 +148,9 @@ class GenericHandler @Inject() (
 
           case Some(length) => {
             Results.Status(response.status).
-              sendEntity(
-                HttpEntity.Streamed(response.bodyAsSource, Some(length.toLong), Some(contentType.toStringWithEncoding))
-              ).
-              withHeaders(Util.toFlatSeq(responseHeaders): _*)
+              sendEntity(HttpEntity.Streamed(response.bodyAsSource, Some(length.toLong), None)).
+              withHeaders(Util.toFlatSeq(responseHeaders): _*).
+              as(contentType.toStringWithEncoding)
           }
         }
       }


### PR DESCRIPTION
See: https://service.us2.sumologic.com/ui/#/search/QvnnxvXvsJySlpBwPkwEYp192gQBPqHIYzeyoJyV

```
"Explicitly set HTTP header 'Content-Type: application/json' is ignored, explicit `Content-Type` header is not allowed. Set `HttpResponse.entity.contentType` instead."
```