### PR TITLE
CORE-2572: Manually remove content-type in `result` coming out of log filter

### DIFF
--- a/app/filters/Filters.scala
+++ b/app/filters/Filters.scala
@@ -86,11 +86,20 @@ class LoggingFilter @Inject() (
         log.withKeyValue("convert_to_metric", convertToLatencyMetric).info(line)
       } else log.info(line)
 
-      val requestTimeStr = requestTime.toString
-      result
-        .withHeaders("Request-Time" -> requestTimeStr)
-        .withHeaders(Constants.Headers.FlowProxyResponseTime -> requestTimeStr)
+      // hack to remove auto-added application/json
+      // fix warning:
+      // "Explicitly set HTTP header 'Content-Type: application/json' is ignored, explicit `Content-Type` header is not allowed."
+      val headersWithoutContentType = result
+        .header
+        .headers
+        .toSeq
+        .filterNot(x => x._1.toLowerCase == "content-type")
+        .toMap ++
+        Map("Request-Time" -> requestTime.toString) ++
+        Map(Constants.Headers.FlowProxyResponseTime -> requestTime.toString)
 
+      val newResultHeader = result.header.copy(headers = headersWithoutContentType)
+      result.copy(header = newResultHeader)
     }
   }
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -37,7 +37,7 @@
     <logger name="io.flow.token.v0.Client" level="WARN" />
     <logger name="io.flow.organization.v0.Client" level="WARN" />
     <logger name="io.flow.session.v0.Client" level="WARN" />
-    <logger name="akka.actor.ActorSystemImpl" level="ERROR" />
+    <logger name="akka.actor.ActorSystemImpl" level="WARN" />
 
     <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
     <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />


### PR DESCRIPTION
Addresses issue for:
```
"Explicitly set HTTP header 'Content-Type: application/json' is ignored, explicit `Content-Type` header is not allowed."
```

Somehow, the logging filter re-adds the content-type that had previously been removed.

Tested this while running proxy locally