### PR TITLE
Revert "Ignore header case when removing"

### DIFF
--- a/app/lib/ErrorHandler.scala
+++ b/app/lib/ErrorHandler.scala
@@ -44,7 +44,7 @@ class ErrorHandler @Inject() (
 
     // add Authorization as header to remove
     val headerKeys = request.headers.keys.toSeq
-    val headers = Util.filterHeaders(request.headers, Constants.Headers.namesToAllow)
+    val headers = Util.filterKeys(request.headers.toMap, Constants.Headers.namesToAllow)
 
     // attempt better grouping of errors
     val fingerprint = Seq(

--- a/app/lib/ProxyRequest.scala
+++ b/app/lib/ProxyRequest.scala
@@ -266,7 +266,7 @@ case class ProxyRequest(
     status: Int,
     body: String,
     contentType: ContentType,
-    headers: Map[String, Seq[String]] = Map()
+    headers: Map[String,Seq[String]] = Map()
   ): Result = {
     if (responseEnvelope) {
       internalResponse(
@@ -285,16 +285,17 @@ case class ProxyRequest(
     }
   }
 
+  private[this] val HeadersToRemove = Set(Constants.Headers.ContentLength, Constants.Headers.ContentType)
   private[this] def internalResponse(
     status: Int,
     body: String,
     contentType: ContentType,
     headers: Map[String,Seq[String]]
   ): Result = {
+    val responseHeaders = Util.removeKeys(headers, HeadersToRemove)
+
     Status(status)(body).
-      withHeaders(Util.toFlatSeq(headers): _*).
-      discardingHeader(Constants.Headers.ContentLength).
-      discardingHeader(Constants.Headers.ContentType).
+      withHeaders(Util.toFlatSeq(responseHeaders): _*).
       as(contentType.toStringWithEncoding)
   }
 

--- a/app/lib/Util.scala
+++ b/app/lib/Util.scala
@@ -1,7 +1,5 @@
 package lib
 
-import play.api.mvc.Headers
-
 object Util {
 
   def toFlatSeq(data: Map[String, Seq[String]]): Seq[(String, String)] = {
@@ -19,21 +17,22 @@ object Util {
     }
   }
 
-  def removeHeaders(
-    headers: Headers,
-    toRemove: Set[String],
-  ): Headers = {
-    headers.remove(toRemove.toSeq: _*)
+  def removeKeys(
+    data: Map[String, Seq[String]],
+    keys: Set[String],
+  ): Map[String, Seq[String]] = {
+    data.filter { case (k, _) =>
+      !keys.contains(k)
+    }
   }
 
-  def filterHeaders(
-    data: Headers,
-    toKeep: Set[String]
+  def filterKeys(
+    data: Map[String, Seq[String]],
+    keys: Set[String]
   ): Map[String, Seq[String]] = {
-    (for {
-      key <- toKeep
-      if data.hasHeader(key)
-    } yield key -> data.getAll(key)).toMap
+    data.filter { case (k, _) =>
+      keys.contains(k)
+    }
   }
 
 }

--- a/test/lib/UtilSpec.scala
+++ b/test/lib/UtilSpec.scala
@@ -1,7 +1,6 @@
 package lib
 
 import helpers.BasePlaySpec
-import play.api.mvc.Headers
 
 class UtilSpec extends BasePlaySpec {
 
@@ -30,26 +29,26 @@ class UtilSpec extends BasePlaySpec {
     parts.keys.toSeq must equal(Seq("foo"))
   }
 
-  "removeHeaders" in {
-    val parts = Util.removeHeaders(
-      Headers(
-        "foo" -> "bar",
-        "foo2" -> "baz",
+  "removeKeys" in {
+    val parts = Util.removeKeys(
+      Map[String, Seq[String]](
+        "foo" -> Seq("bar"),
+        "foo2" -> Seq("baz")
       ),
-      Set("a", "Foo2")
+      Set("a", "foo2")
     )
     parts.keys.toSeq must equal(Seq("foo"))
   }
 
-  "filterHeaders" in {
-    val parts = Util.filterHeaders(
-      Headers(
-        "foo" -> "bar",
-        "foo2" -> "baz",
+  "filterKeys" in {
+    val parts = Util.filterKeys(
+      Map[String, Seq[String]](
+        "foo" -> Seq("bar"),
+        "foo2" -> Seq("baz")
       ),
-      Set("a", "Foo2")
+      Set("a", "foo2")
     )
-    parts.keys.toSeq must equal(Seq("Foo2"))
+    parts.keys.toSeq must equal(Seq("foo2"))
   }
 
   "query with multiple values" in {


### PR DESCRIPTION
Reverts flowvault/proxy#494

prod errors:
 `akka.http.scaladsl.model.EntityStreamException: Entity stream truncation. The HTTP parser was receiving an entity when the underlying connection was closed unexpectedly.`